### PR TITLE
Add default console routes bootstrap

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,3 +1,8 @@
 <?php
 
-require __DIR__.'/examples/console.php';
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+
+Artisan::command('inspire', function () {
+    $this->comment(Inspiring::quote());
+})->purpose('Display an inspiring quote');


### PR DESCRIPTION
## Summary
- replace the placeholder console routes file with Laravel's default console bootstrap
- register the sample `inspire` Artisan command so the console routes file can be safely included by the bootstrap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d18704eb108326af4f0feb2428fc78