### PR TITLE
Restore default console routes documentation

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,3 +1,19 @@
 <?php
 
-require __DIR__.'/examples/console.php';
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+
+/*
+|--------------------------------------------------------------------------
+| Console Routes
+|--------------------------------------------------------------------------
+|
+| This file is where you may define all of your Closure based console
+| commands. Each Closure is bound to a command instance allowing a
+| simple approach to interacting with each command's IO methods.
+|
+*/
+
+Artisan::command('inspire', function () {
+    $this->comment(Inspiring::quote());
+})->purpose('Display an inspiring quote');


### PR DESCRIPTION
## Summary
- restore Laravel's default documentation block in `routes/console.php` so the console bootstrap matches the framework scaffold

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d18704eb108326af4f0feb2428fc78